### PR TITLE
Add plugin toggle for saving user column preferences to database

### DIFF
--- a/plugins/system/usercolumns/language/en-GB/plg_system_usercolumns.ini
+++ b/plugins/system/usercolumns/language/en-GB/plg_system_usercolumns.ini
@@ -2,3 +2,5 @@
 ; (C) 2026 Open Source Matters, Inc. <https://www.joomla.org>
 ; License GNU General Public License version 2 or later; see LICENSE.txt
 ; Note : All ini files need to be saved as UTF-8
+PLG_SYSTEM_USERCOLUMNS_FIELD_SAVE_DATABASE_LABEL="Save to database"
+PLG_SYSTEM_USERCOLUMNS_FIELD_SAVE_DATABASE_DESC="If disabled, column visibility preferences are only saved in browser localStorage and are not synced to the user profile."

--- a/plugins/system/usercolumns/src/Extension/UserColumns.php
+++ b/plugins/system/usercolumns/src/Extension/UserColumns.php
@@ -71,8 +71,8 @@ final class UserColumns extends CMSPlugin implements SubscriberInterface
             return;
         }
 
-        // Tell the JS it is safe to sync column state to the server.
-        $app->getDocument()->addScriptOptions('table.columns.sync', true);
+        // Tell the JS whether it is safe to sync column state to the server.
+        $app->getDocument()->addScriptOptions('table.columns.sync', (bool) $this->params->get('save_database', 1));
 
         $stored = $user->getParam('hidden_tablecolumns', '');
 
@@ -109,6 +109,10 @@ final class UserColumns extends CMSPlugin implements SubscriberInterface
         $app = $this->getApplication();
 
         if (!($app instanceof AdministratorApplication)) {
+            return;
+        }
+
+        if (!(bool) $this->params->get('save_database', 1)) {
             return;
         }
 

--- a/plugins/system/usercolumns/usercolumns.xml
+++ b/plugins/system/usercolumns/usercolumns.xml
@@ -18,4 +18,24 @@
         <language tag="en-GB">en-GB/plg_system_usercolumns.ini</language>
         <language tag="en-GB">en-GB/plg_system_usercolumns.sys.ini</language>
     </languages>
+    <config>
+        <fields name="params">
+            <fieldset name="basic">
+                <field
+                    name="save_database"
+                    type="radio"
+                    label="PLG_SYSTEM_USERCOLUMNS_FIELD_SAVE_DATABASE_LABEL"
+                    description="PLG_SYSTEM_USERCOLUMNS_FIELD_SAVE_DATABASE_DESC"
+                    default="1"
+                    class="btn-group btn-group-yesno"
+                    filter="integer"
+                    validate="options"
+                    layout="joomla.form.field.radio.switcher"
+                    >
+                    <option value="1">JENABLED</option>
+                    <option value="0">JDISABLED</option>
+                </field>
+            </fieldset>
+        </fields>
+    </config>
 </extension>


### PR DESCRIPTION
### Motivation
- Provide a plugin-level toggle to control whether admin table column visibility preferences are synced to the user profile (database) while keeping local browser storage always enabled.
- Allow administrators to disable database writes for the User Columns feature for privacy/performance without removing localStorage-based preferences.

### Description
- Added a `save_database` yes/no plugin parameter to `plugins/system/usercolumns/usercolumns.xml` to expose the toggle in plugin configuration.
- Added English language strings `PLG_SYSTEM_USERCOLUMNS_FIELD_SAVE_DATABASE_LABEL` and `PLG_SYSTEM_USERCOLUMNS_FIELD_SAVE_DATABASE_DESC` in `plugins/system/usercolumns/language/en-GB/plg_system_usercolumns.ini`.
- Updated `plugins/system/usercolumns/src/Extension/UserColumns.php` so `table.columns.sync` follows the `save_database` parameter and the AJAX save handler returns early when database saving is disabled, preventing DB writes while leaving localStorage behavior unchanged.

### Testing
- Ran `php -l plugins/system/usercolumns/src/Extension/UserColumns.php` which reported no syntax errors (success).
- Validated the plugin XML with `php -r "new SimpleXMLElement(file_get_contents('plugins/system/usercolumns/usercolumns.xml')); echo 'XML OK';"` which printed `XML OK` (success).
- Attempted `xmllint --noout plugins/system/usercolumns/usercolumns.xml` but `xmllint` is not available in this environment (warning).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a59481d80c8330b744eee2493f090d)